### PR TITLE
Fix HTTP connections to Elastic

### DIFF
--- a/core/elastic.py
+++ b/core/elastic.py
@@ -1,9 +1,12 @@
 import re
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 from elasticsearch_dsl import Search
 from graph.config import conf
 
-client = Elasticsearch(conf.get("elasticsearch.hostname"), timeout=30)
+client = Elasticsearch(
+    conf.get("elasticsearch.hostname"),
+    timeout=30,
+    connection_class=RequestsHttpConnection)
 
 def query_cache_paper_info(author_id):
     result = {}

--- a/core/elastic.py
+++ b/core/elastic.py
@@ -6,7 +6,8 @@ from graph.config import conf
 client = Elasticsearch(
     conf.get("elasticsearch.hostname"),
     timeout=30,
-    connection_class=RequestsHttpConnection)
+    connection_class=RequestsHttpConnection,
+    http_compress=True)
 
 def query_cache_paper_info(author_id):
     result = {}

--- a/core/elastic.py
+++ b/core/elastic.py
@@ -279,9 +279,6 @@ def check_browse_record_exists(cachetype, displayname):
 def author_order_query(paper_id):
     ''' Find author name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Query for paa
     authors_s = Search(index = 'paperauthoraffiliations', using = client)
     authors_s = authors_s.query('term', PaperId=paper_id)

--- a/core/search/cache_data.py
+++ b/core/search/cache_data.py
@@ -5,17 +5,15 @@ date:   24.06.18
 author: Alexander Soen
 '''
 
-from graph.config import conf
-from elasticsearch import Elasticsearch, helpers
+from elasticsearch import helpers
 from elasticsearch_dsl import Search
+
+from core.elastic import client
 from core.search.query_utility import paper_info_to_cache_json
 
 def cache_paper_info(paper_infos, chunk_size=20, request_timeout=100, additional_tag={}):
     ''' Converts and caches a single paper info dictionary.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Convert into cache-able json
     paper_info_chunks = [paper_infos[i:i+chunk_size] for i in \
                     range(0, len(paper_infos), chunk_size)]

--- a/core/search/query_info_cache.py
+++ b/core/search/query_info_cache.py
@@ -6,11 +6,10 @@ author: Alexander Soen
 '''
 from datetime import datetime
 
-from graph.config import conf
+from core.elastic import client
 from core.search.query_utility import field_del
 from core.search.query_utility import chunker
 
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 
 
@@ -22,9 +21,6 @@ def paper_info_cache_query(
     """ Gets paper info from cache.
     """
     start = datetime.now()
-
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
 
     # Query results
     complete_info = list()

--- a/core/search/query_info_db.py
+++ b/core/search/query_info_db.py
@@ -13,11 +13,10 @@ author: Alexander Soen
 import copy
 from datetime import datetime
 
-from graph.config import conf
+from core.elastic import client
 from core.search.query_info_cache import base_paper_cache_query
 from core.search.query_name_db import *
 
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
 
 TIMEOUT = 60
@@ -25,9 +24,6 @@ TIMEOUT = 60
 def papers_prop_query(paper_ids):
     ''' Get properties of a paper.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Targets
     papers_targets = ['PaperTitle', 'ConferenceSeriesId', 'JournalId', 'Year']
 
@@ -76,10 +72,6 @@ def papers_prop_query(paper_ids):
 def paa_prop_query(paper_ids):
     ''' Get properties of a paper.
     '''
-
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Targets
     paa_targets = ['PaperId', 'AuthorId', 'AffiliationId']
 
@@ -144,10 +136,6 @@ def paa_prop_query(paper_ids):
 def pfos_prop_query(paper_ids):
     ''' Get properties of a paper.
     '''
-
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Targets
     pfos_targets = ['PaperId', 'FieldOfStudyId']
 
@@ -201,9 +189,6 @@ def pfos_prop_query(paper_ids):
 def pr_links_query(paper_ids):
     ''' Get properties of a paper.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Targets
     pr_targets = ['PaperId', 'PaperReferenceId', 'FieldOfStudyId']
 

--- a/core/search/query_name_db.py
+++ b/core/search/query_name_db.py
@@ -5,18 +5,14 @@ date:   24.06.18
 author: Alexander Soen
 '''
 
-from graph.config import conf
+from core.elastic import client
 from core.utils.entity_type import Entity_type
 
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 
 def author_name_query(author_ids):
     ''' Find author name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     authors_targets = ['AuthorId', 'NormalizedName']
 
@@ -35,9 +31,6 @@ def author_name_query(author_ids):
 def author_name_dict_query(author_ids):
     ''' Find author name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     authors_target = 'NormalizedName'
 
@@ -58,9 +51,6 @@ def author_name_dict_query(author_ids):
 def fos_name_level_dict_query(fos_ids):
     ''' Find field of study name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     fos_target = ['NormalizedName', 'Level']
 
@@ -83,9 +73,6 @@ def fos_name_level_dict_query(fos_ids):
 def affiliation_name_query(affiliation_ids):
     ''' Find affiliation name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     affi_target = 'NormalizedName'
 
@@ -106,9 +93,6 @@ def affiliation_name_query(affiliation_ids):
 def affiliation_name_dict_query(affiliation_ids):
     ''' Find affiliation name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     affi_target = 'NormalizedName'
 
@@ -129,9 +113,6 @@ def affiliation_name_dict_query(affiliation_ids):
 def conference_name_query(conference_ids):
     ''' Find conference name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     conf_target = 'NormalizedName'
 
@@ -152,9 +133,6 @@ def conference_name_query(conference_ids):
 def conference_name_dict_query(conference_ids):
     ''' Find conference name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     conf_target = 'NormalizedName'
 
@@ -175,9 +153,6 @@ def conference_name_dict_query(conference_ids):
 def journal_name_query(journal_ids):
     ''' Find journal name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     jour_target = 'NormalizedName'
 
@@ -198,9 +173,6 @@ def journal_name_query(journal_ids):
 def journal_name_dict_query(journal_ids):
     ''' Find journal name from id.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     jour_target = 'NormalizedName'
 
@@ -269,9 +241,6 @@ def name_dict_query(entity_type, entity_name):
 def normalized_to_display(entity_name, index):
     '''
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Query for paa
     query_s = Search(index=index, using=client)
     query_s = query_s.query('match', NormalizedName=entity_name)

--- a/core/search/query_paper_db.py
+++ b/core/search/query_paper_db.py
@@ -5,18 +5,14 @@ date:   24.06.18
 author: Alexander Soen
 '''
 
-from graph.config import conf
+from core.elastic import client
 from core.utils.entity_type import Entity_type
 
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 
 def author_paper_query(author_ids):
     ''' Query author id for availible papers.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     paa_target = 'PaperId'
 
@@ -38,9 +34,6 @@ def author_paper_query(author_ids):
 def affiliation_paper_query(affi_ids):
     ''' Query affiliation id for availible papers.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     paa_target = 'PaperId'
 
@@ -62,9 +55,6 @@ def affiliation_paper_query(affi_ids):
 def conference_paper_query(conf_ids):
     ''' Query conference (instance) id for availible papers.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     papers_target = 'PaperId'
 
@@ -87,9 +77,6 @@ def conference_paper_query(conf_ids):
 def journal_paper_query(jour_ids):
     ''' Query journal id for availible papers.
     '''
-    # Elastic search client
-    client = Elasticsearch(conf.get("elasticsearch.hostname"))
-
     # Target
     papers_target = 'PaperId'
 

--- a/graph/copy_old_to_new_cache.py
+++ b/graph/copy_old_to_new_cache.py
@@ -1,10 +1,8 @@
 from multiprocessing import Pool
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
-from graph.config import conf
-from graph.save_cache import saveNewBrowseCache
 
-client = Elasticsearch(conf.get("elasticsearch.hostname"))
+from core.elastic import client
+from graph.save_cache import saveNewBrowseCache
 
 def get_documents(index):
     result = []

--- a/scripts/cache_paper_info.py
+++ b/scripts/cache_paper_info.py
@@ -6,10 +6,9 @@ import json
 
 from datetime import datetime
 
-from graph.config import conf
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
 
+from core.elastic import client
 from core.search.query_info import paper_info_db_check_multiquery
 
 #%%
@@ -33,10 +32,6 @@ try:
         print(BATCH_SIZE)
 except FileExistsError:
     pass
-
-#%%
-# Elastic search client
-client = Elasticsearch(conf.get('elasticsearch.hostname'))
 
 #%%
 counter = 0

--- a/scripts/update_for_fos.py
+++ b/scripts/update_for_fos.py
@@ -3,18 +3,16 @@ Update cache to include fos information
 '''
 from datetime import datetime
 
-from graph.config      import conf
-from elasticsearch     import Elasticsearch
 from elasticsearch_dsl import Search, Q
 
-from core.search.query_info_db    import paper_info_multiquery
-from core.search.cache_data       import cache_paper_info
+from core.elastic import client
+from core.search.cache_data import cache_paper_info
+from core.search.query_info_db import paper_info_multiquery
 
 # Constants
 NUM_PAPERS = 1
 
 # Elastic search client
-client = Elasticsearch(conf.get("elasticsearch.hostname"))
 
 THRESHOLD_DATE = datetime(2019, 3, 6, 10, 43, 45, 734484) 
 

--- a/scripts/update_paper_info.py
+++ b/scripts/update_paper_info.py
@@ -6,10 +6,9 @@ import json
 
 from datetime import datetime
 
-from graph.config import conf
-from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
 
+from core.elastic import client
 from core.search.query_info_db import paper_info_multiquery
 from core.search.cache_data import cache_paper_info
 
@@ -34,10 +33,6 @@ try:
         print(BATCH_SIZE)
 except FileExistsError:
     pass
-
-#%%
-# Elastic search client
-client = Elasticsearch(conf.get('elasticsearch.hostname'))
 
 #%%
 query = Q('bool',

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -1,5 +1,5 @@
 import os
-from webapp.elastic import *
+from core.elastic import *
 
 from core.flower.high_level_get_flower import default_config
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -22,7 +22,7 @@ from core.search.query_paper import get_all_paper_ids
 from core.utils.get_stats import get_stats
 from core.utils.load_tsv import tsv_to_dict
 from graph.save_cache import *
-from webapp.elastic import *
+from core.elastic import *
 from webapp.graph import ReferenceFlower, compare_flowers
 from webapp.shortener import shorten_front, unshorten_url_ext
 from webapp.utils import *


### PR DESCRIPTION
- Reuse Elasticsearch connections
- Use Requests instead of Urllib3
- Compress data in transit

These changes halve the time we spend retrieving data from Elasticsearch from 1.7s to 0.9s. The total request time goes from 2.8s to 2.0s (28% improvement).